### PR TITLE
Use white background on initial state of outline buttons

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -44,6 +44,7 @@
   $active-color: color-contrast($active-background)
 ) {
   --#{$prefix}btn-color: #{$color};
+  --#{$prefix}btn-bg: #fff;
   --#{$prefix}btn-border-color: #{$color};
   --#{$prefix}btn-hover-color: #{$color-hover};
   --#{$prefix}btn-hover-bg: #{$active-background};


### PR DESCRIPTION
### Description

Added #fff value to btn-bg variable on mixin used by outline buttons.

### Motivation & Context

UX requested that outline buttons have white background in their initial state. Using `bg-white` with the button class (eg `btn-outline-primary`) overrode the hover and focus styles and in some cases made text completely unreadable.

