### PR TITLE
add .icon-sm-font-size

### DIFF
--- a/scss/_janus_variables.scss
+++ b/scss/_janus_variables.scss
@@ -297,40 +297,43 @@ $table-color:                 $gray-900 !default;
 $table-cell-padding-y:        $janus-table-cell-padding-y !default;
 $table-cell-padding-x:        $janus-table-cell-padding-x !default;
 
-
+.icon-sm-font-size {
+  width: $janus-icon-sm-font-size;
+  height: $janus-icon-sm-font-size;
+}
 
 .icon-base-font-size {
-    width: $janus-icon-base-font-size;
-    height: $janus-icon-base-font-size;
-  }
+  width: $janus-icon-base-font-size;
+  height: $janus-icon-base-font-size;
+}
   
-  .icon-lg-font-size {
-    width: $janus-icon-lg-font-size;
-    height: $janus-icon-lg-font-size;
-  }
+.icon-lg-font-size {
+  width: $janus-icon-lg-font-size;
+  height: $janus-icon-lg-font-size;
+}
   
-  .icon-xl-font-size {
-    width: $janus-icon-xl-font-size;
-    height: $janus-icon-xl-font-size;
-  }
+.icon-xl-font-size {
+  width: $janus-icon-xl-font-size;
+  height: $janus-icon-xl-font-size;
+}
   
-  .icon-xxl-font-size {
-    width: $janus-icon-xxl-font-size;
-    height: $janus-icon-xxl-font-size;
-  }
+.icon-xxl-font-size {
+  width: $janus-icon-xxl-font-size;
+  height: $janus-icon-xxl-font-size;
+}
   
-  .text-shadow-none {
-    text-shadow: none;
-  }
+.text-shadow-none {
+  text-shadow: none;
+}
   
+svg {
+  stroke-width: 1.5;
+}
+  
+[class^="tabler-chevron-"] {
   svg {
-    stroke-width: 1.5;
+    stroke-width: 2;
   }
-  
-  [class^="tabler-chevron-"] {
-    svg {
-      stroke-width: 2;
-    }
-  }
+}
 
 /* stylelint-enable */


### PR DESCRIPTION
### Description

Adding a new icon size (.icon-sm-font-size) and fixing indendation

### Motivation & Context

The sorting icons (chevron-up and chevron-down) in janus theme are using size 12x12

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)