### PR TITLE
Capitalize buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -34,6 +34,7 @@
   color: var(--#{$prefix}btn-color);
   text-align: center;
   text-decoration: if($link-decoration == none, null, none);
+  text-transform: capitalize;
   white-space: $btn-white-space;
   vertical-align: middle;
   cursor: if($enable-button-pointers, pointer, null);


### PR DESCRIPTION
Bringing button capitalization back until dictionary update work can be done in tandem with removing this rule again.