### PR TITLE
Override btn-primary within alerts to use matching button style

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -63,6 +63,10 @@
     --#{$prefix}alert-bg: var(--#{$prefix}#{$state}-bg-subtle);
     --#{$prefix}alert-border-color: var(--#{$prefix}#{$state}-border-subtle);
     --#{$prefix}alert-link-color: var(--#{$prefix}#{$state}-text-emphasis);
+    // Override btn-primary within alerts to use matching button style.
+    .btn-primary {
+      @extend .btn-#{$state};
+    }
   }
 }
 // scss-docs-end alert-modifiers


### PR DESCRIPTION
![Screenshot 2024-08-26 at 4 47 39 PM](https://github.com/user-attachments/assets/a116d0bd-f3be-4673-9893-bd41b01f64db)
